### PR TITLE
Updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "ch.ictrust.pobya"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 14
-        versionName "1.6.1"
+        versionCode 15
+        versionName "1.6.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
         kapt {
@@ -61,7 +61,7 @@ android {
             excludes += ['META-INF/DEPENDENCIES', 'META-INF/LICENSE', 'META-INF/LICENSE.txt']
             excludes += ['META-INF/license.txt', 'META-INF/NOTICE', 'META-INF/NOTICE.txt', 'META-INF/notice.txt']
             excludes += [ 'META-INF/ASL2.0', 'META-INF/*.kotlin_module', 'META-INF/INDEX.LIST']
-            excludes += ['**/DebugProbesKt.bin']
+            excludes += ['**/DebugProbesKt.bin', '**/publicsuffixes.gz']
         }
     }
     namespace 'ch.ictrust.pobya'

--- a/app/src/main/java/ch/ictrust/pobya/adapter/AppsAdapter.kt
+++ b/app/src/main/java/ch/ictrust/pobya/adapter/AppsAdapter.kt
@@ -175,7 +175,10 @@ class AppsAdapter(ctx: Context) : ListAdapter<InstalledApplication, AppsAdapter.
         val status = ApplicationPermissionHelper(context, (currentApp.isSystemApp == 1))
                             .getAppConfidence(context.packageManager.getPackageInfo(currentApp.packageName, PackageManager.GET_PERMISSIONS or PackageManager.GET_META_DATA))
 
-        if (currentApp.applicationState != status && !currentApp.applicationState.equals(ApplicationState.MALWARE)) {
+        if (currentApp.applicationState != status &&
+            ! (currentApp.applicationState.equals(ApplicationState.MALWARE) ||
+                    currentApp.applicationState.equals(ApplicationState.SUSPICIOUS))
+            ){
             currentApp.applicationState = status
             Utilities.scanAppScope.launch {
                 ApplicationRepository.getInstance(context.applicationContext as Application)

--- a/app/src/main/java/ch/ictrust/pobya/fragment/DataSafetyPolicyFragment.kt
+++ b/app/src/main/java/ch/ictrust/pobya/fragment/DataSafetyPolicyFragment.kt
@@ -32,11 +32,6 @@ class DataSafetyPolicyFragment : Fragment() {
 
     lateinit var wvDataSafetyPolicyFragment: WebView
 
-    companion object
-    {
-        var flag: Boolean = false
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -48,7 +43,6 @@ class DataSafetyPolicyFragment : Fragment() {
 
             wvDataSafetyPolicyFragment = view.findViewById(R.id.wvDataSafetyPolicy)
             try {
-                wvDataSafetyPolicyFragment.settings.javaScriptEnabled = true
                 wvDataSafetyPolicyFragment.loadUrl("file:///android_res/raw/policy.html")
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/app/src/main/java/ch/ictrust/pobya/service/MalwareScanService.kt
+++ b/app/src/main/java/ch/ictrust/pobya/service/MalwareScanService.kt
@@ -111,7 +111,6 @@ class MalwareScanService : Service() {
                 CVDVersionRepository.getInstance(application).getLast(CVDType.DAILY)
 
             if (lastUpdate == null || (Date().time - lastUpdate.updateDate) < 86400000) {
-                // TODO: remove hardcoded strings
                 scanStatus.postValue(applicationContext.getString(R.string.updating))
                 if (Utilities.updateMalwareDB(applicationContext)) {
                     scanStatus.postValue(applicationContext.getString(R.string.success))


### PR DESCRIPTION
- Avoid refresh application state when flagged as Suspicious or malware
- exclude publicsuffixes.gz: Cookies are not used and publicsuffixes.gz is flagged by Symantec Mobile Insight as AdLibrary:Generisk 